### PR TITLE
docs(demo): update fuzzing example

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -132,155 +132,81 @@ Youtube video
 [![Solving malformed ELF header + Anti-Debug crackme, with Qiling GDBserver + Qiling qltool](https://i.ytimg.com/vi/TYGZ-GVRIaA/0.jpg)](https://www.youtube.com/watch?v=TYGZ-GVRIaA)
 
 
-### Fuzzing with Qiling Unicornafl
+### Fuzzing with Qiling's AFL extension 
 
-More information on fuzzing with Qiling Unicornafl can be found [here](https://github.com/qilingframework/qiling/tree/dev/examples/fuzzing/README.md).
+Qiling can be used to fuzz binary or firmware with AFL++'s unicorn mode
+
+Note that the demo code may be outdated, more information on fuzzing with Qiling can be found [here](https://github.com/qilingframework/qiling/tree/master/examples/fuzzing).
+
+The general steps should be like this:
+```sh
+# Build AFL++'s unicorn mode
+git clone https://github.com/AFLplusplus/AFLplusplus.git -b dev
+make -C AFLplusplus
+cd AFLplusplus/unicorn_mode ; ./build_unicorn_support.sh
+
+# Fuzz simple x86_64 binary
+AFL_AUTORESUME=1 AFL_PATH="$(realpath ./AFLplusplus)" PATH="$AFL_PATH:$PATH" afl-fuzz -i afl_inputs -o afl_outputs -U -- python3 ./fuzz_x8664_linux.py @@
+```
 
 Example code
 ```python
-import unicornafl
+# No more need for importing unicornafl, try afl.ql_afl_fuzz instead!
+import os
+import sys
 
-# Make sure Qiling uses our patched unicorn instead of it's own, second so without instrumentation!
-unicornafl.monkeypatch()
+from typing import Optional
 
-import sys, os
-from binascii import hexlify
+sys.path.append("../../..")
+from qiling import Qiling
+from qiling.const import QL_VERBOSE
+from qiling.extensions import pipe
+from qiling.extensions import afl
 
-from capstone.x86_const import *
+def main(input_file: str):
+    ql = Qiling(["./x8664_fuzz"], "../../rootfs/x8664_linux",
+        verbose=QL_VERBOSE.OFF, # keep qiling logging off
+        console=False)          # thwart program output
 
-sys.path.append("../..")
-from qiling import *
+    # redirect stdin to our mock to feed it with incoming fuzzed keystrokes
+    ql.os.stdin = pipe.SimpleInStream(sys.stdin.fileno())
 
-# we cache this for some extra speed
-stdin_fstat = os.fstat(sys.stdin.fileno())
+    def place_input_callback(ql: Qiling, input: bytes, persistent_round: int) -> Optional[bool]:
+        """Feed generated stimuli to the fuzzed target.
 
-# This is mostly taken from the crackmes
-class MyPipe():
-    def __init__(self):
-        self.buf = b''
-
-    def write(self, s):
-        self.buf += s
-
-    def read(self, size):
-        if size <= len(self.buf):
-            ret = self.buf[: size]
-            self.buf = self.buf[size:]
-        else:
-            ret = self.buf
-            self.buf = ''
-        return ret
-
-    def fileno(self):
-        return 0
-
-    def show(self):
-        pass
-
-    def clear(self):
-        pass
-
-    def flush(self):
-        pass
-
-    def close(self):
-        self.outpipe.close()
-
-    def fstat(self):
-        return stdin_fstat
-
-
-def main(input_file, enable_trace=False):
-    stdin = MyPipe()
-    ql = Qiling(["./x8664_fuzz"], "../rootfs/x8664_linux",
-                stdin=stdin,
-                stdout=1 if enable_trace else None,
-                stderr=1 if enable_trace else None,
-                console = True if enable_trace else False)
-
-    # or this for output:
-    # ... stdout=sys.stdout, stderr=sys.stderr)
-
-    def place_input_callback(uc, input, _, data):
-        stdin.write(input)
-
-    def start_afl(_ql: Qiling):
+        This method is called with every fuzzing iteration.
         """
-        Callback from inside
+
+        # feed fuzzed input to our mock stdin
+        ql.os.stdin.write(input)
+
+        # signal afl to proceed with this input
+        return True
+
+    def start_afl(ql: Qiling):
+        """Have Unicorn fork and start instrumentation.
         """
-        # We start our AFL forkserver or run once if AFL is not available.
-        # This will only return after the fuzzing stopped.
-        try:
-            #print("Starting afl_fuzz().")
-            if not _ql.uc.afl_fuzz(input_file=input_file,
-                        place_input_callback=place_input_callback,
-                        exits=[ql.os.exit_point]):
-                print("Ran once without AFL attached.")
-                os._exit(0)  # that's a looot faster than tidying up.
-        except unicornafl.UcAflError as ex:
-            # This hook trigers more than once in this example.
-            # If this is the exception cause, we don't care.
-            # TODO: Chose a better hook position :)
-            if ex != unicornafl.UC_AFL_RET_CALLED_TWICE:
-                raise
-    
-    # 64 bit loader addrs are placed at 0x7ffbf0100000
-    # see loader/elf.py:load_with_ld(..)
-    X64BASE = int(ql.profile.get("OS64", "load_address"),16)
-    
-    # crash in case we reach stackcheck_fail:
-    # 1225:	e8 16 fe ff ff       	callq  1040 <__stack_chk_fail@plt>
-    ql.hook_address(callback=lambda x: os.abort(), address=X64BASE + 0x1225)
 
-    # Add hook at main() that will fork Unicorn and start instrumentation.
-    # main starts at X64BASE + 0x122c
-    main_addr = X64BASE + 0x122c
-    ql.hook_address(callback=start_afl, address=main_addr)
+        afl.ql_afl_fuzz(ql, input_file=input_file, place_input_callback=place_input_callback, exits=[ql.os.exit_point])
 
-    if enable_trace:
-        # The following lines are only for `-t` debug output
+    # get image base address
+    ba = ql.loader.images[0].base
 
-        md = Cs(CS_ARCH_X86, CS_MODE_64)
-        count = [0]
+    # make the process crash whenever __stack_chk_fail@plt is about to be called.
+    # this way afl will count stack protection violations as crashes
+    ql.hook_address(callback=lambda x: os.abort(), address=ba + 0x1225)
 
-        def spaced_hex(data):
-            return b' '.join(hexlify(data)[i:i+2] for i in range(0, len(hexlify(data)), 2)).decode('utf-8')
+    # set afl instrumentation [re]starting point. we set it to 'main'
+    ql.hook_address(callback=start_afl, address=ba + 0x122c)
 
-        def disasm(count, ql, address, size):
-            buf = ql.mem.read(address, size)
-            try:
-                for i in md.disasm(buf, address):
-                    return "{:08X}\t{:08X}: {:24s} {:10s} {:16s}".format(count[0], i.address, spaced_hex(buf), i.mnemonic,
-                                                                        i.op_str)
-            except:
-                import traceback
-                print(traceback.format_exc())
-
-        def trace_cb(ql, address, size, count):
-            rtn = '{:100s}'.format(disasm(count, ql, address, size))
-            print(rtn)
-            count[0] += 1
-
-        ql.hook_code(trace_cb, count)
-
-    # okay, ready to roll.
-    # try:
+    # okay, ready to roll
     ql.run()
-    # except Exception as ex:
-    #     # Probable unicorn memory error. Treat as crash.
-    #     print(ex)
-    #     os.abort()
-
-    os._exit(0)  # that's a looot faster than tidying up.
-
 
 if __name__ == "__main__":
     if len(sys.argv) == 1:
         raise ValueError("No input file provided.")
-    if len(sys.argv) > 2 and sys.argv[1] == "-t":
-        main(sys.argv[2], enable_trace=True)
-    else:
-        main(sys.argv[1])
+
+    main(sys.argv[1])
 ```
 
 


### PR DESCRIPTION
The afl fuzzing feature of Qiling has changed a lot, so I
- update the 404 url
- add examples to build AFL++'s unicorn mode
- replace the outdated example code with the newest one in https://github.com/qilingframework/qiling/blob/master/examples/fuzzing/linux_x8664/fuzz_x8664_linux.py